### PR TITLE
Support pycryptodomex

### DIFF
--- a/ref-py/nist_kat_drbg.py
+++ b/ref-py/nist_kat_drbg.py
@@ -6,7 +6,7 @@ Copyright (c) 2023 Raccoon Signature Team. See LICENSE.
     the randombutes() call in the NIST KAT testing suite.
 """
 
-from Crypto.Cipher import AES
+from symmetric import AES
 
 class NIST_KAT_DRBG:
     def __init__(self, seed):

--- a/ref-py/racc_api.py
+++ b/ref-py/racc_api.py
@@ -5,7 +5,7 @@ Copyright (c) 2023 Raccoon Signature Team. See LICENSE.
 === Masked Raccoon signature scheme: Serialization, parameters, BUFF interface.
 """
 
-from Crypto.Hash import SHAKE256
+from symmetric import SHAKE256
 from nist_kat_drbg import NIST_KAT_DRBG
 from mask_random import MaskRandom
 from racc_core import Raccoon

--- a/ref-py/racc_core.py
+++ b/ref-py/racc_core.py
@@ -7,7 +7,7 @@ Copyright (c) 2023 Raccoon Signature Team. See LICENSE.
 
 import os
 
-from Crypto.Hash import SHAKE256
+from symmetric import SHAKE256
 from nist_kat_drbg import NIST_KAT_DRBG
 from mask_random import MaskRandom
 from polyr import *

--- a/ref-py/symmetric.py
+++ b/ref-py/symmetric.py
@@ -1,0 +1,13 @@
+"""
+symmetric.py
+Copyright (c) 2023 Raccoon Signature Team. See LICENSE.
+
+=== Support file to handle pycryptodome and pycryptodomex
+"""
+
+try:
+    from Crypto.Cipher import AES
+    from Crypto.Hash import SHAKE256
+except ImportError:
+    from Cryptodome.Cipher import AES
+    from Cryptodome.Hash import SHAKE256


### PR DESCRIPTION
Ubuntu's `python3-cryptodome` installs `pycryptodomex` under the hood. This package is the same, but instead of the `Crypto` namespace, it uses the `Cryptodome` namespace.

This PR introduces some opportunistic loading to handle both versions of the `pycryptodome` library.